### PR TITLE
fix ci and rename opam file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # following https://github.com/coq-community/docker-coq-action
 
-name: Docker CI
+name: CI
 
 on:
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,5 @@ jobs:
       - uses: actions/checkout@v5
       - uses: coq-community/docker-coq-action@v1
         with:
-          opam_file: 'coq-hol-light-real-with-N.opam'
+          opam_file: 'mathcomp-hollight-real-with-N.opam'
           coq_version: ${{ matrix.coq_version }}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 HOL-Light definition of real numbers in Rocq using N and MathComp
 -----------------------------------------------------------------
 
-This [Rocq](https://rocq-prover.org/) library contains an automatic translation of a subset of the [HOL-Light](https://github.com/jrh13/hol-light) base library [lib_hol.ml](https://github.com/jrh13/hol-light/blob/master/lib_hol.ml) up to the definition of real numbers in the file [real.ml](https://github.com/jrh13/hol-light/blob/master/real.ml), with various HOL-Light types and functions [mapped](https://github.com/Deducteam/coq-hol-light-real-with-N/blob/main/mappings.lp) to the corresponding types and functions of the Rocq standard library so that, for instance, a HOL-Light theorem on HOL-Light natural numbers is translated to a Rocq theorem on the Rocq type N of natural numbers in base 2. The provided theorems can therefore be readily used within other Rocq developments based on the Rocq standard library. The translation has been done using [hol2dk](https://github.com/Deducteam/hol2dk) to extract and translate HOL-Light proofs to Lambdapi files, and [lambdapi](https://github.com/Deducteam/lambdapi) to translate Lambdapi files to Rocq files.
+This [Rocq](https://rocq-prover.org/) library contains an automatic translation of a subset of the [HOL-Light](https://github.com/jrh13/hol-light) base library [lib_hol.ml](https://github.com/jrh13/hol-light/blob/master/lib_hol.ml) up to the definition of real numbers in the file [real.ml](https://github.com/jrh13/hol-light/blob/master/real.ml), with various HOL-Light types and functions [mapped](https://github.com/Deducteam/mathcomp-hollight-real-with-N/blob/main/mappings.lp) to the corresponding types and functions of the Rocq standard library or the MathComp library (sets) so that, for instance, a HOL-Light theorem on HOL-Light natural numbers is translated to a Rocq theorem on the Rocq type N of natural numbers in base 2. The provided theorems can therefore be readily used within other Rocq developments based on the Rocq standard library. The translation has been done using [hol2dk](https://github.com/Deducteam/hol2dk) to extract and translate HOL-Light proofs to Lambdapi files, and [lambdapi](https://github.com/Deducteam/lambdapi) to translate Lambdapi files to Rocq files.
 
 This library is used as a basis for the alignment of real numbers in the much larger library [coq-hol-light](https://github.com/Deducteam/coq-hol-light) which contains a translation of more than 20,000 HOL-Light theorems on arithmetic, wellfounded relations, lists, real numbers, integers, basic set theory, permutations, group theory, matroids, metric spaces, homology, vectors, determinants, topology, convex sets and functions, paths, polytopes, Brouwer degree, derivatives, Clifford algebra, integration, measure theory, complex numbers and analysis, transcendental numbers, real analysis, complex line integrals, etc.
 
-The translated theorems are provided as axioms in order to have a fast Require because the proofs currently extracted from HOL-Light may be big and not very informative for they are low level (the translation is done at the kernel level, not at the source level). If you are skeptical, you can however generate and check them again by using the script [reproduce](https://github.com/Deducteam/hol2dk/blob/main/reproduce). It takes about 7 minutes with 32 processors Intel Core i9-13950HX and 64 Gb RAM. If every thing works well, the proofs are available in the directory `tmp/output`.
+The translated theorems are provided as axioms in order to have a fast Require because the proofs currently extracted from HOL-Light may be big and not very informative for they are low level (the translation is done at the kernel level, not at the source level). If you are skeptical, you can however generate and check them again by using the script [reproduce](https://github.com/Deducteam/mathcomp-hollight-real-with-N/blob/main/reproduce). It takes about 7 minutes with 32 processors Intel Core i9-13950HX and 64 Gb RAM. If every thing works well, the proofs are available in the directory `tmp/output`.
 
-The types and functions currently [aligned](https://github.com/Deducteam/coq-hol-light-real-with-N/blob/main/mappings.lp) are:
+The types and functions currently [aligned](https://github.com/Deducteam/mathcomp-hollight-real-with-N/blob/main/mappings.lp) are:
 - types: unit, prod, list, option, sum, ascii, N
 - functions on N: pred, add, mul, pow, le, lt, ge, gt, max, min, sub, div, modulo, even, odd, factorial
 - functions on list: app, rev, map, fold_right, removelast, combine, In, hd, tl, last, Forall, Forall2, Exists, nth*, length*, repeat*, filter**\
@@ -20,13 +20,13 @@ More types and functions are aligned in [coq-hol-light](https://github.com/Deduc
 
 You can easily contribute by proving the correctness of more mappings in Rocq:
 
-- Look in [terms.v](https://github.com/Deducteam/coq-hol-light-real-with-N/blob/main/terms.v) for the definition of a function symbol, say f, that you want to replace; note that it is followed by a lemma f_def stating what f is equal to.
+- Look in [terms.v](https://github.com/Deducteam/mathcomp-hollight-real-with-N/blob/main/terms.v) for the definition of a function symbol, say f, that you want to replace; note that it is followed by a lemma f_def stating what f is equal to.
 
-- Copy and paste in [mappings.v](https://github.com/Deducteam/coq-hol-light-real-with-N/blob/main/mappings.v) the lemma f_def, and try to prove it if f is replaced by your own function.
+- Copy and paste in [mappings.v](https://github.com/Deducteam/mathcomp-hollight-real-with-N/blob/main/mappings.v) the lemma f_def, and try to prove it if f is replaced by your own function.
 
-- Create a [pull request](https://github.com/Deducteam/coq-hol-light-real-with-N/pulls).
+- Create a [pull request](https://github.com/Deducteam/mathcomp-hollight-real-with-N/pulls).
 
-You can also propose to change the mapping of some type in [mappings.v](https://github.com/Deducteam/coq-hol-light-real-with-N/blob/main/mappings.v). Every HOL-Light type `A` is axiomatized as being isomorphic to the subset of elements `x` of some already defined type `B` that satisfies some property `p:B->Prop`. `A` can always be mapped to the Rocq type `{x:B|p(x)}` (see [mappings.v](https://github.com/Deducteam/coq-hol-light-real-with-nat/blob/main/mappings.v)) but it is possible to map it to some more convenient type `A'` by defining two functions:
+You can also propose to change the mapping of some type in [mappings.v](https://github.com/Deducteam/mathcomp-hollight-real-with-N/blob/main/mappings.v). Every HOL-Light type `A` is axiomatized as being isomorphic to the subset of elements `x` of some already defined type `B` that satisfies some property `p:B->Prop`. `A` can always be mapped to the Rocq type `{x:B|p(x)}` (see [mappings.v](https://github.com/Deducteam/coq-hol-light-real-with-nat/blob/main/mappings.v)) but it is possible to map it to some more convenient type `A'` by defining two functions:
 
 - `mk:B->A'`
 
@@ -56,13 +56,13 @@ Axiom proof_irrelevance : forall (P:Prop) (p1 p2:P), p1 = p2.
 
 ```
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam install coq-hol-light-real-with-N
+opam install rocq-mathcomp-hollight-real-with-N
 ```
 
 **Usage in a Rocq file**
 
 ```
-Require Import HOLLight_Real_With_N.theorems.
+Require Import MathComp_HOLLight_Real_With_N.theorems.
 Check thm_DIV_DIV.
 ```
 

--- a/mathcomp-hollight-real-with-N.opam
+++ b/mathcomp-hollight-real-with-N.opam
@@ -14,7 +14,6 @@ license: "CeCILL-2.1"
 depends: [
   "coq-mathcomp-classical" {>= "1.8.0"}
   "rocq-prover" {>= "9.0"}
-  "dune" {>= "3.18"} # https://gitlab.inria.fr/fpottier/menhir/-/issues/81
 ]
 build: [make "-j%{jobs}%"]
 install: [make "install"]

--- a/mathcomp-hollight-real-with-N.opam
+++ b/mathcomp-hollight-real-with-N.opam
@@ -14,6 +14,7 @@ license: "CeCILL-2.1"
 depends: [
   "coq-mathcomp-classical" {>= "1.8.0"}
   "rocq-prover" {>= "9.0"}
+  "dune" {>= "3.18"} # https://gitlab.inria.fr/fpottier/menhir/-/issues/81
 ]
 build: [make "-j%{jobs}%"]
 install: [make "install"]

--- a/mathcomp-hollight-real-with-N.opam
+++ b/mathcomp-hollight-real-with-N.opam
@@ -14,6 +14,7 @@ license: "CeCILL-2.1"
 depends: [
   "coq-mathcomp-classical" {>= "1.8.0"}
   "rocq-prover" {>= "9.0"}
+  "rocq-hierarchy-builder"
 ]
 build: [make "-j%{jobs}%"]
 install: [make "install"]

--- a/mathcomp-hollight-real-with-N.opam
+++ b/mathcomp-hollight-real-with-N.opam
@@ -14,7 +14,6 @@ license: "CeCILL-2.1"
 depends: [
   "coq-mathcomp-classical" {>= "1.8.0"}
   "rocq-prover" {>= "9.0"}
-  "rocq-hierarchy-builder"
 ]
 build: [make "-j%{jobs}%"]
 install: [make "install"]

--- a/reproduce
+++ b/reproduce
@@ -16,7 +16,7 @@ camlp5_version=8.03.06
 hollight_file=hol_upto_real.ml
 base=`basename $hollight_file .ml`
 dump_simp_option=-before-hol
-opam_file=rocq-mathcomp-hol-light-real-with-N.opam
+opam_file=mathcomp-hollight-real-with-N.opam
 root_path=MathComp_HOLLight_Real_With_N
 jobs='-j32'
 


### PR DESCRIPTION
CI fails on rocq-dev because of some menhir files requiring a dune version greater than the one pinned by docker-coq-action

see https://gitlab.inria.fr/fpottier/menhir/-/issues/81